### PR TITLE
Allow same parameter name in different scopes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Background
+
+[AT-](https://homebot.atlassian.net/browse/AT-)
+[ST-](https://homebot.atlassian.net/browse/ST-)
+
+## Changes
+
+- {change 1}
+- {change 2}
+
+## TODO
+
+- [ ] TODO 1
+- [ ] TODO 2
+
+## Deployment Notes
+
+Explain if this is backward breaking, has any hard version requirements to another app or any other forseeable risk(s).

--- a/features/open_api.feature
+++ b/features/open_api.feature
@@ -193,6 +193,8 @@ Feature: Generate Open API Specification from test examples
           parameter :name, 'The order name', required: true, scope: :data, with_example: true
           parameter :amount, required: false, scope: :data, with_example: true
           parameter :description, 'The order description', required: true, scope: :data, with_example: true
+          parameter :address, 'The seller address', scope: [:data, :seller]
+          parameter :address, 'The buyer address', scope: [:data, :buyer]
 
           header "Content-Type", "application/json"
 
@@ -697,6 +699,24 @@ Feature: Generate Open API Specification from test examples
                           "type": "string",
                           "example": "fast order",
                           "description": "The order description"
+                        },
+                        "seller": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "The seller address"
+                            }
+                          }
+                        },
+                        "buyer": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "The buyer address"
+                            }
+                          }
                         }
                       },
                       "required": [

--- a/lib/rspec_api_documentation/writers/open_api_writer.rb
+++ b/lib/rspec_api_documentation/writers/open_api_writer.rb
@@ -159,7 +159,7 @@ module RspecApiDocumentation
       end
 
       def extract_parameters(example)
-        parameters = example.extended_parameters.uniq { |parameter| parameter[:name] }
+        parameters = example.extended_parameters.uniq { |parameter| [parameter[:name], parameter[:scope]] }
 
         extract_known_parameters(parameters.select { |p| !p[:in].nil? }) +
           extract_unknown_parameters(example, parameters.select { |p| p[:in].nil? })


### PR DESCRIPTION
## Background

- Gem was calling`.uniq` on the params when generating the request schema docs, so when there are two `type` params (one for the main object being created, the other for relationship... _see example schema below_), only one was showing up in the docs.
```javascript
{
  "data": {
    "type": "loan-officers",    // main object type
    "attributes": {
      "email": "garrett@example.com",
      "nmls": "990099"
    },
    "relationships": {
      "office-profile": {
        "data": {
          "id": "5871c15b-1ea2-4f47-a6e8-7b48e1ee4aaf",
          "type": "office-profiles"    // related object type
        }
      }
    }
  }
}
```

## Changes

- Scope uniqueness to... scope?